### PR TITLE
Upgrade yarn to his latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ RUN apt-get update && \
      libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
      libnss3 \
     && rm -rf /var/lib/apt/lists/*
+    
+RUN npm install -g yarn


### PR DESCRIPTION
Yarn is at version 1.3.2 in the container. It can be useful to upgrade to its latest version to make `yarn install` steps be faster.